### PR TITLE
Remove reference to collections.Hashable (removed in Python 3.10)

### DIFF
--- a/telepotpro/__init__.py
+++ b/telepotpro/__init__.py
@@ -1421,7 +1421,7 @@ class DelegatorBot(SpeakerBot):
 
             if id is None:
                 continue
-            elif isinstance(id, collections.Hashable):
+            elif isinstance(id, collections.abc.Hashable):
                 if id not in dict or not dict[id].is_alive():
                     d = make_delegate((self, msg, id))
                     d = self._ensure_startable(d)

--- a/telepotpro/aio/__init__.py
+++ b/telepotpro/aio/__init__.py
@@ -920,7 +920,7 @@ class DelegatorBot(SpeakerBot):
 
             if id is None:
                 continue
-            elif isinstance(id, collections.Hashable):
+            elif isinstance(id, collections.abc.Hashable):
                 if id not in dict or dict[id].done():
                     c = make_coroutine_obj((self, msg, id))
 


### PR DESCRIPTION
Hi, I have removed references to collections.Hashable as it was removed in Python 3.10 and it was raising an error.
It now refers collections.abc.Hashable, which was introduced with Python 3.3 (so this may break compatibility with earlier versions, but after all, it was also released 13 years ago).
